### PR TITLE
Make valid, toCents and toDollars more robust

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/TabDigital/dollar-string/issues"
   },
   "dependencies": {
-    "big.js": "~2.5.1"
+    "big.js": "~3.0.0"
   },
   "devDependencies": {
     "mocha": "~2.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -11,14 +11,17 @@ var addDollarSign = function(value) {
 }
 
 exports.toCents = function(dollarString) {
-  if(typeof(dollarString) !== 'string') {
-    return dollarString;
+  if (!exports.valid(dollarString)) {
+    return null;
   }
   dollarString = stripDollarSign(dollarString);
   return parseInt(big(dollarString).times(100).toFixed(0));
 }
 
 exports.toDollars = function(dollarString) {
+  if (!exports.valid(dollarString)) {
+    return null;
+  }
   return parseFloat(stripDollarSign(dollarString));
 }
 
@@ -52,5 +55,5 @@ exports.multipleOf = function(val1, val2) {
 }
 
 exports.valid = function(value) {
-  return VALID_DOLLAR_STRING_REGEX.test(value);
+  return typeof(value) == 'string' && VALID_DOLLAR_STRING_REGEX.test(value);
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -12,6 +12,12 @@ describe('DollarString', function(){
       dollarString.toCents('$1.50').should.equal(150);
       dollarString.toCents('$2.22').should.equal(222);
     });
+
+    it('should return null or undefined for invalid input', function() {
+      should.not.exist(dollarString.toCents('abc'));
+      should.not.exist(dollarString.toCents(''));
+      should.not.exist(dollarString.toCents());
+    });
   });
 
   describe('ToDollars', function() {
@@ -22,6 +28,12 @@ describe('DollarString', function(){
     it('should convert dollar string with cents to number in dollars', function() {
       dollarString.toDollars('$1.50').should.equal(1.5);
       dollarString.toDollars('$2.22').should.equal(2.22);
+    });
+
+    it('should return null or undefined for invalid input', function() {
+      should.not.exist(dollarString.toDollars('abc'));
+      should.not.exist(dollarString.toDollars(''));
+      should.not.exist(dollarString.toDollars());
     });
   });
 
@@ -89,6 +101,12 @@ describe('DollarString', function(){
       dollarString.valid("$1.004").should.equal(false);
       dollarString.valid("$1.00c").should.equal(false);
       dollarString.valid("$1.a0").should.equal(false);
+      dollarString.valid("abc").should.equal(false);
+      dollarString.valid("").should.equal(false);
+      dollarString.valid(123).should.equal(false);
+      dollarString.valid({}).should.equal(false);
+      dollarString.valid([]).should.equal(false);
+      dollarString.valid().should.equal(false);
     });
   })
 });


### PR DESCRIPTION
- valid: make sure the input is a string object before perform regex match
- toCents and toDollars: return null if input is invalid

Also upgrade big.js to latest stable version
